### PR TITLE
Fixed broken links. Tested & working, no warnings remain.

### DIFF
--- a/docs/en/spec/examples.md
+++ b/docs/en/spec/examples.md
@@ -212,7 +212,7 @@ inspection_train ,1 ,4 ,sign-off ,                    ,main_terminal ,03:00:00 ,
 
 ## Distinct Crew and Trip schedule scenarios
 
-These examples show situations where the crew schedules in `run_events.txt` use different service IDs than the trips they work on, as is allowed by [the spec](/spec#service_id-crew-schedules-and-trip-schedules). Most agencies will not need to model a situation like this.
+These examples show situations where the crew schedules in `run_events.txt` use different service IDs than the trips they work on, as is allowed by [the spec](index.md#service_id-crew-schedules-and-trip-schedules). Most agencies will not need to model a situation like this.
 
 In all these cases, the trips and service IDs in the public GTFS file are not modified. New service IDs are created in the calendar supplement files, and runs that operate on those dates are described in `run_events.txt`.
 
@@ -335,7 +335,7 @@ date,service_id,block_id,vehicle_id
 
 ## Employee Assignments
 
-This example uses [`employee_run_dates.txt`](/spec#employee_run_datestxt) to assign employees to runs (and trips).
+This example uses [`employee_run_dates.txt`](index.md#employee_run_datestxt) to assign employees to runs (and trips).
 
 In this example, `A` and `B` work Monday-Wednesday and Sunday. `C` and `D` work Thursday-Saturday.
 
@@ -351,7 +351,7 @@ weekend,0,0,0,0,0,1,1,20240701,20240707
 
 July 1, 2024 was a Monday.
 
-**[`run_events.txt`](/spec#run_eventstxt)**
+**[`run_events.txt`](index.md#run_eventstxt)**
 
 For this example, the purpose of this file is just to show which runs exist. Real runs would have more interesting data.
 
@@ -363,7 +363,7 @@ weekend,103,1,work,trip3,station,09:00:00,station,17:00:00
 weekend,104,1,work,trip4,station,09:00:00,station,17:00:00
 ```
 
-**[`employee_run_dates.txt`](/spec#employee_run_datestxt)**
+**[`employee_run_dates.txt`](index.md#employee_run_datestxt)**
 
 ```csv
 date,service_id,run_id,employee_id

--- a/docs/en/spec/index.md
+++ b/docs/en/spec/index.md
@@ -132,7 +132,7 @@ Primary Key: (`service_id`, `run_id`, `event_sequence`)
 
 For most agencies, crew schedules will use the same schedule as trips do. The `service_id` in `run_events.txt` will be the same `service_id` as is in `trips.txt` for all the trips that run works on, and the TODS feed won't need any additional entries in `calendar_supplement.txt`.
 
-Some agencies schedule crew schedules separately from vehicle/trip schedules, and runs and trips may occur on different `service_id`s. For example, a trip that occurs on service ID `weekday` may be worked by run `1` on service ID `monday`, and by run `2` on service ID `tuesday`. See the [examples](/spec/examples) for some situations where this may happen. In that case, `trips.txt:service_id` refers to dates when the trip occurs, and `run_events.txt:service_id` refers to the dates where the run works that trip. This means that producers do not need to rewrite the calendar for their public GTFS trip schedules in order to publish complex crew schedules in TODS.
+Some agencies schedule crew schedules separately from vehicle/trip schedules, and runs and trips may occur on different `service_id`s. For example, a trip that occurs on service ID `weekday` may be worked by run `1` on service ID `monday`, and by run `2` on service ID `tuesday`. See the [examples](examples.md) for some situations where this may happen. In that case, `trips.txt:service_id` refers to dates when the trip occurs, and `run_events.txt:service_id` refers to the dates where the run works that trip. This means that producers do not need to rewrite the calendar for their public GTFS trip schedules in order to publish complex crew schedules in TODS.
 
 Consumers who care about the dates that a trip occurs should use the `trip_id` (which is unique even across different services) to look up the trip in `trips.txt`, and get the `service_id` there.
 
@@ -200,7 +200,7 @@ Primary Key: `(date, block_id, service_id)`
 | Field Name | Type | Required | Description |
 |---|---|---|---|
 | `date` | Date | Required |  |
-| `service_id` | ID referencing `calendar.service_id` or `calendar_dates.service_id` | Optional | Identifies a set of *service days* when the trip is scheduled to take place. Note the [https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#term-definitions](GTFS definition) of *service day* is invoked here. Required if `block_id`s are repeated between different `service_id`s. |
+| `service_id` | ID referencing `calendar.service_id` or `calendar_dates.service_id` | Optional | Identifies a set of *service days* when the trip is scheduled to take place. Note the [GTFS definition](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#term-definitions) of *service day* is invoked here. Required if `block_id`s are repeated between different `service_id`s. |
 | `block_id`		  | ID referencing `trips.block_id` | Required | Identifies the block. |
 | `vehicle_id` | ID referencing `vehicles.vehicle_id` | Required | Refers to a specific vehicle in the transit fleet. |
 


### PR DESCRIPTION
```
INFO | Doc file 'spec/index-d' contains an absolute link '/spec/examples', it was left as is. Did you mean 'examples.md'?
INFO | Doc file 'spec/index.md' contains an unrecognized relative link 'GTFS definition', it was left as is.
INFO | Doc file 'spec/examples.md' contains an absolute link '/spec#service_id-crew-schedules-and-trip-schedules', it was left as is. Did you mean 'index.md#service_id-crew-schedules-and-trip-schedules'
INFO | Doc file 'spec/examples.md' contains an absolute link '/spec#employee_run_datestxt', it was left as is. Did you mean 'index.md#employee_run_datestxt'?
INFO | Doc file 'spec/examples.nd' contains an absolute link /spec#run_eventstxt', it was left as is. Did you mean 'index.md#run_eventstxt'?
INFO | Doc file 'spec/examples.md' contains an absolute link '/spec#employee_run_datestxt', it was left as is. Did you mean 'index.md#employee_run_datestxt'?
```